### PR TITLE
Use Express4 route instead of app. Fixes ejs view

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -7,17 +7,14 @@ im = require('imagemagick-stream'),
 common;
 
 module.exports = function(config){
-  var app = express(),
+  var router = express.Router();
   staticFiles = config.staticFiles,
   common = require('./common')(config),
   album = require('./album')(config),
   photo = require('./photo')(config);
+    
   
-  app.set('views', path.join(__dirname, '..', 'views'));
-  app.set('view engine', 'ejs');
-  
-  
-  app.get('/gallery.css', function(req, res, next){
+  router.get('/gallery.css', function(req, res, next){
     var fstream = fs.createReadStream(path.join(__dirname, '..', 'css/gallery.css'));
     res.type('text/css');
     fstream.on('error', function(err){
@@ -27,7 +24,7 @@ module.exports = function(config){
   });
   
   // Photo Page
-  app.get(/.+(\.(jpg|bmp|jpeg|gif|png|tif)(\?tn=(1|0))?)$/i, function(req, res, next){
+  router.get(/.+(\.(jpg|bmp|jpeg|gif|png|tif)(\?tn=(1|0))?)$/i, function(req, res, next){
     var filePath = path.join(staticFiles, req.path),
     fstream;
     
@@ -99,9 +96,9 @@ module.exports = function(config){
   });
   
   // Photo Pages - anything containing */photo/*
-  app.get(/(.+\/)?photo\/(.+)/i, photo, common.render);
+  router.get(/(.+\/)?photo\/(.+)/i, photo, common.render);
   // Album Page - everything that doesn't contain the photo string
   // regex source http://stackoverflow.com/questions/406230/regular-expression-to-match-string-not-containing-a-word
-  app.get(/^((?!\/photo\/).)*$/, album, common.render);
-  return app;
+  router.get(/^((?!\/photo\/).)*$/, album, common.render);
+  return router;
 }

--- a/views/album.ejs
+++ b/views/album.ejs
@@ -1,5 +1,3 @@
-<link href="/<%= urlRoot %>/gallery.css" rel="stylesheet" type="text/css">
-
 <% if (!isRoot){ %>
   <nav class="breadcrumb">
 

--- a/views/photo.ejs
+++ b/views/photo.ejs
@@ -1,5 +1,3 @@
-<link href="/<%= urlRoot %>/gallery.css" rel="stylesheet" type="text/css">
-
 <nav class="breadcrumb">
 <% for (var i=0; i<breadcrumb.length; i++) { %>
 


### PR DESCRIPTION
Integrating you gallery into my express app, res.render had problems finding my view directory.
After changing from app to router I am fine.
For standalone "views" and "view engine" are already set in examples/app.js so no need to set twice. I suspect you needed to set it again since a new app can not be aware of it. But router is.
